### PR TITLE
Add timeout to flush buffer if last flush was longer than x seconds a…

### DIFF
--- a/kafka_influxdb/config/default_config.py
+++ b/kafka_influxdb/config/default_config.py
@@ -22,6 +22,7 @@ DEFAULT_CONFIG = {
     },
     'encoder': 'kafka_influxdb.encoder.collectd_graphite_encoder',
     'buffer_size': 1000,
+    'buffer_timeout': False,
     'configfile': None,
     'c': None,
     'statistics': False,

--- a/kafka_influxdb/config/loader.py
+++ b/kafka_influxdb/config/loader.py
@@ -131,6 +131,9 @@ def parse_args(args=sys.argv[1:]):
     parser.add_argument('--buffer_size', type=int, default=argparse.SUPPRESS,
                         help="Maximum number of messages that will be collected before flushing to the backend "
                              "(default: 1000)")
+    parser.add_argument('--buffer_timeout', type=int, default=argparse.SUPPRESS,
+                        help="Maximum age (seconds) of messages in buffer before flushing to the backend "
+                             "(default: False)")
     parser.add_argument('-c', '--configfile', type=str, default=argparse.SUPPRESS,
                         help="Configfile path (default: None)")
     parser.add_argument('-s', '--statistics', default=argparse.SUPPRESS, action="store_true",

--- a/kafka_influxdb/reader/confluent.py
+++ b/kafka_influxdb/reader/confluent.py
@@ -61,6 +61,7 @@ class Reader(ReaderAbstract):
             if __debug__:
                 logging.debug(msg)
             if msg is None:
+                yield False
                 continue
             if msg.error():
                 self._handle_error(msg)

--- a/kafka_influxdb/tests/test_worker.py
+++ b/kafka_influxdb/tests/test_worker.py
@@ -44,7 +44,6 @@ class TimeoutReader(object):
         self.timeout = timeout
 
     def read(self):
-        # Yield the first half of messages
         for i in range(self.num_messages-1):
             yield self.message
         # Simulate no additional messages causing timeout

--- a/kafka_influxdb/tests/test_worker.py
+++ b/kafka_influxdb/tests/test_worker.py
@@ -49,8 +49,8 @@ class TimeoutReader(object):
         # Simulate no additional messages causing timeout
         time.sleep(self.timeout)
         yield False
-        # Simulate keyboard interrupt by user to stop consuming
-        raise KeyboardInterrupt
+        # Stop consuming
+        raise SystemExit
 
 class FlakyReader(object):
     """

--- a/kafka_influxdb/worker.py
+++ b/kafka_influxdb/worker.py
@@ -59,6 +59,8 @@ class Worker(object):
                 logging.info("Shutdown. Flushing remaining messages from buffer.")
                 self.flush()
                 break
+            except SystemExit:
+                break
 
     def init_database(self):
         """


### PR DESCRIPTION
…go. Set with --buffer_timeout, disabled by default, can be used in conjunction with --buffer_size. Tested with confluent reader.