### PR TITLE
Make Kafka offset configurable (closes #58)

### DIFF
--- a/kafka_influxdb/__main__.py
+++ b/kafka_influxdb/__main__.py
@@ -42,7 +42,8 @@ def start_consumer(config):
         config.kafka_host,
         config.kafka_port,
         config.kafka_group,
-        config.kafka_topic
+        config.kafka_topic,
+        config.kafka_offset
     )
     logging.debug("Initializing connection to InfluxDB at %s:%s",
                   config.influxdb_host, config.influxdb_port)

--- a/kafka_influxdb/config/default_config.py
+++ b/kafka_influxdb/config/default_config.py
@@ -6,6 +6,7 @@ DEFAULT_CONFIG = {
         'group': 'kafka-influxdb',
         'reconnect_wait_time_ms': 1000,
         'reader': 'kafka_influxdb.reader.confluent',
+        'offset': 'largest',
     },
     'influxdb': {
         'host': 'localhost',
@@ -18,7 +19,7 @@ DEFAULT_CONFIG = {
         'timeout': 5,
         'use_udp': False,
         'retention_policy': 'autogen',
-        'time_precision': 's'
+        'time_precision': 's',
     },
     'encoder': 'kafka_influxdb.encoder.collectd_graphite_encoder',
     'buffer_size': 1000,

--- a/kafka_influxdb/config/loader.py
+++ b/kafka_influxdb/config/loader.py
@@ -96,6 +96,8 @@ def parse_args(args=sys.argv[1:]):
                         help="Port of Kafka message broker (default: 9092)")
     parser.add_argument('--kafka_topic', type=str, default=argparse.SUPPRESS,
                         help="Topic for metrics (default: my_topic)")
+    parser.add_argument('--kafka_offset', type=str, default=argparse.SUPPRESS,
+                        help="Kafka offset (default: largest)")
     parser.add_argument('--kafka_group', type=str, default=argparse.SUPPRESS,
                         help="Kafka consumer group (default: my_group)")
     parser.add_argument('--kafka_reconnect_wait_time_ms', type=int, default=argparse.SUPPRESS,

--- a/kafka_influxdb/reader/__init__.py
+++ b/kafka_influxdb/reader/__init__.py
@@ -1,12 +1,12 @@
 import importlib
 
 
-def load_reader(name, host, port, group, topic):
+def load_reader(name, host, port, group, topic, offset):
     """
     Creates an instance of the given reader.
-    An reader consumes messages from Kafka.
+    A reader consumes messages from Kafka.
     """
     reader_module = importlib.import_module(name)
     reader_class = getattr(reader_module, "Reader")
     # Return an instance of the class
-    return reader_class(host, port, group, topic)
+    return reader_class(host, port, group, topic, offset)

--- a/kafka_influxdb/reader/confluent.py
+++ b/kafka_influxdb/reader/confluent.py
@@ -10,6 +10,9 @@ class Reader(ReaderAbstract):
     See: https://github.com/confluentinc/confluent-kafka-python
     """
 
+    def __init__(self, host, port, group, topic, broker_version=KAFKA_VERSION_ZOOKEEPER_OPTIONAL):
+        super().__init__(host, port, group, topic, broker_version=KAFKA_VERSION_ZOOKEEPER_OPTIONAL)
+
     def _subscribe(self):
         """
         Subscribe to Kafka topics.
@@ -34,7 +37,7 @@ class Reader(ReaderAbstract):
             'offset.store.method': 'broker',
             'default.topic.config': {
                 # TODO: Make this configurable
-                'auto.offset.reset': 'largest'  # smallest
+                'auto.offset.reset': self.offset # 'largest'  # smallest
             }
         }
         # Add additional flag based on the Kafka version.

--- a/kafka_influxdb/reader/confluent.py
+++ b/kafka_influxdb/reader/confluent.py
@@ -10,9 +10,6 @@ class Reader(ReaderAbstract):
     See: https://github.com/confluentinc/confluent-kafka-python
     """
 
-    def __init__(self, host, port, group, topic, broker_version=KAFKA_VERSION_ZOOKEEPER_OPTIONAL):
-        super().__init__(host, port, group, topic, broker_version=KAFKA_VERSION_ZOOKEEPER_OPTIONAL)
-
     def _subscribe(self):
         """
         Subscribe to Kafka topics.

--- a/kafka_influxdb/reader/confluent.py
+++ b/kafka_influxdb/reader/confluent.py
@@ -33,8 +33,9 @@ class Reader(ReaderAbstract):
             'group.id': self.group,
             'offset.store.method': 'broker',
             'default.topic.config': {
-                # TODO: Make this configurable
-                'auto.offset.reset': self.offset # 'largest'  # smallest
+                # In newer Kafka versions, this can either be 'largest' or 'smallest'.
+                # See https://kafka.apache.org/documentation/
+                'auto.offset.reset': self.offset
             }
         }
         # Add additional flag based on the Kafka version.

--- a/kafka_influxdb/reader/reader.py
+++ b/kafka_influxdb/reader/reader.py
@@ -14,7 +14,7 @@ class ReaderAbstract(object):
     # The specific workarounds required are documented below.
     KAFKA_VERSION_ZOOKEEPER_OPTIONAL = "0.9.0"
 
-    def __init__(self, host, port, group, topic, broker_version=KAFKA_VERSION_ZOOKEEPER_OPTIONAL):
+    def __init__(self, host, port, group, topic, offset, broker_version=KAFKA_VERSION_ZOOKEEPER_OPTIONAL):
         """
         Initialize Kafka reader
         """
@@ -22,6 +22,7 @@ class ReaderAbstract(object):
         self.port = str(port)
         self.group = group
         self.topic = topic
+        self.offset = offset
         self.broker_version = broker_version
 
         # Initialized on read

--- a/kafka_influxdb/tests/reader_test/test_confluent.py
+++ b/kafka_influxdb/tests/reader_test/test_confluent.py
@@ -19,6 +19,7 @@ class TestConfluentKafka(unittest.TestCase):
         self.port = 1234
         self.group = "mygroup"
         self.topic = "mytopic"
+        self.offset = "largest"
         self.reconnect_wait_time = 0.01
         self.reader = self.create_reader()
 
@@ -26,7 +27,8 @@ class TestConfluentKafka(unittest.TestCase):
         reader = confluent.Reader(self.host,
                                   self.port,
                                   self.group,
-                                  self.topic)
+                                  self.topic,
+                                  self.offset)
         reader.consumer = mock.MagicMock()
         return reader
 

--- a/kafka_influxdb/tests/reader_test/test_kafka_python.py
+++ b/kafka_influxdb/tests/reader_test/test_kafka_python.py
@@ -10,6 +10,7 @@ class TestKafkaPython(unittest.TestCase):
         self.port = 1234
         self.group = "mygroup"
         self.topic = "mytopic"
+        self.offset = "largest"
         self.reconnect_wait_time = 0.01
         self.reader = self.create_reader()
 
@@ -17,7 +18,8 @@ class TestKafkaPython(unittest.TestCase):
         reader = kafka_python.Reader(self.host,
                                      self.port,
                                      self.group,
-                                     self.topic)
+                                     self.topic,
+                                     self.offset)
         reader.consumer = mock.MagicMock()
         return reader
 


### PR DESCRIPTION
This change makes the Kafka offset configurable.
Until now, it was hardcoded to always use the `largest` index, but this will now allow for overwriting this with e.g. `smallest`.
@mimmus fyi

See #58 for more info. 