### PR TITLE
Bug when using the echo_encoder

### DIFF
--- a/kafka_influxdb/encoder/echo_encoder.py
+++ b/kafka_influxdb/encoder/echo_encoder.py
@@ -8,9 +8,9 @@ except ImportError:
 class Encoder(object):
     @staticmethod
     def encode(msg):
-        # type: (bytes) -> List[bytes]
+        # type: (bytes) -> List[Text]
         """
         Don't change the message at all
         :param msg:
         """
-        return [msg]
+        return [msg.decode('utf-8')]

--- a/kafka_influxdb/tests/encoder_test/test_echo_encoder.py
+++ b/kafka_influxdb/tests/encoder_test/test_echo_encoder.py
@@ -16,7 +16,7 @@ class TestEchoEncoder(unittest.TestCase):
 
     def test_encode(self):
         for msg in self.messages:
-            yield self.check_encode(msg)
+            yield self.check_encode(msg.encode())
 
     def check_encode(self, msg):
         """ Output must be same as input for echo sender """

--- a/kafka_influxdb/writer/influxdb_writer.py
+++ b/kafka_influxdb/writer/influxdb_writer.py
@@ -85,11 +85,10 @@ class InfluxDBWriter(object):
         See https://influxdb.com/docs/v0.9/write_protocols/line.html
         :param expected_response_code:
         :param params:
-        :param msg: msg is a list of bytes coming in
+        :param msg: List[Text]
         """
 
         # Since msg is a list of bytes snippets, we cast those to strings
-        decoded_msg = [m.decode('utf-8') for m in msg]
 
         if not params:
             # Use defaults
@@ -100,7 +99,7 @@ class InfluxDBWriter(object):
             self.client.request(url='write',
                                 method='POST',
                                 params=params,
-                                data="\n".join(decoded_msg),
+                                data="\n".join(msg),
                                 expected_response_code=expected_response_code,
                                 headers=self.headers
                                 )

--- a/kafka_influxdb/writer/influxdb_writer.py
+++ b/kafka_influxdb/writer/influxdb_writer.py
@@ -85,8 +85,12 @@ class InfluxDBWriter(object):
         See https://influxdb.com/docs/v0.9/write_protocols/line.html
         :param expected_response_code:
         :param params:
-        :param msg:
+        :param msg: msg is a list of bytes coming in
         """
+
+        # Since msg is a list of bytes snippets, we cast those to strings
+        decoded_msg = [m.decode('utf-8') for m in msg]
+
         if not params:
             # Use defaults
             params = self.params
@@ -96,7 +100,7 @@ class InfluxDBWriter(object):
             self.client.request(url='write',
                                 method='POST',
                                 params=params,
-                                data="\n".join(msg),
+                                data="\n".join(decoded_msg),
                                 expected_response_code=expected_response_code,
                                 headers=self.headers
                                 )


### PR DESCRIPTION
I began investigating because, when using the `echo_encoder`, I was getting an error: `TypeError: sequence item 0 expected str instance, bytes found`.  After searching & debugging, I found: 

The `echo_encoder` was of the signature: `(bytes) -> List[bytes]`, but it should be of the signature `(bytes) -> List[Text]` like the other decoders. 

In `influxdb_writer.write`, the `msg` parameter is expected to be a `List[Text]`, but it was receiving a list of bytes from `echo_encoder`. 

This PR basically makes sure to decode raw bytes to `utf-8` in the `echo_encoder`.
